### PR TITLE
Shields not blocking projectiles kept on when equipped

### DIFF
--- a/Source/Patches.cs
+++ b/Source/Patches.cs
@@ -188,7 +188,8 @@ namespace ToggleableShields
 				newApparel.TryGetComp<CompShield>() is CompShield shieldBelt && //Is a shield belt?
 				(__instance.pawn?.equipment?.Primary?.def.IsWeaponUsingProjectiles ?? false) && //Is using a gun?
 				!shieldBelt.parent.def.HasModExtension<StaticShield>() && //Is not a static shield?
-				__instance.pawn.Spawned //Is the pawn actually spawned?
+				__instance.pawn.Spawned && //Is the pawn actually spawned?
+				shieldBelt.Props.blocksRangedWeapons //Is the shield actually blocking usage of guns?
 			)
 			{
 				shieldBelt.energy = -0.0001f;


### PR DESCRIPTION
In vanilla (Biotech), this only affects heavy shield units. As far as I'm aware, those are unobtainable (only worn by mechanoids) but can be spawned with dev mode.